### PR TITLE
feat: optimize efficiency using Socket IPC and direct signaling & add multi-monitor support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2024"
 [dependencies]
 serde = {version = "1.0.228", features = ["derive"]}
 serde_json = "1.0.145"
-
+libc = "0.2"
 


### PR DESCRIPTION
I noticed the current implementation spawns a significant number of processes (via `hyprctl` and `killall`), which can be quite heavy on CPU cycles. Here are a few suggestions to improve efficiency:

- Replace `hyprctl` process spawning with direct Unix Socket communication.
- Replace `killall` commands with direct `libc::kill` signals using the Waybar PID.
- Add multi-monitor support by calculating cursor position relative to monitor offsets.
- Implement adaptive polling to reduce CPU wakeups when the cursor is away from the trigger zone.

Hope it's still as good, works well on my machine :)

Thank you for this!