### PR TITLE
feat: add configurable key-trigger system for Waybar visibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
 name = "clap"
 version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,6 +139,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "evdev"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab6055a93a963297befb0f4f6e18f314aec9767a4bbe88b151126df2433610a7"
+dependencies = [
+ "bitvec",
+ "cfg-if",
+ "libc",
+ "nix",
+ "thiserror",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,6 +194,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "nix"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +238,12 @@ checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "serde"
@@ -196,6 +289,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,6 +309,32 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -229,6 +354,7 @@ name = "waybar_auto_hide"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "evdev",
  "libc",
  "serde",
  "serde_json",
@@ -247,6 +373,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+evdev = "0.12"
 serde = {version = "1.0.228", features = ["derive"]}
 serde_json = "1.0.148"
 libc = "0.2"

--- a/README.md
+++ b/README.md
@@ -1,27 +1,32 @@
 # Waybar Auto-Hide
 
-A lightweight utility that automatically shows/hides Waybar in Hyprland based on cursor position and window state. It will hide waybar when no window is opened in the current workspace, and will temporarly make it visible when the cursor is placed at the top of the screen. 
+A lightweight utility that automatically shows/hides Waybar in Hyprland based on cursor position and window state. It will hide waybar when no window is opened in the current workspace, and will temporarly make it visible when the cursor is placed at the top of the screen.
 
 ## Features
+
 - Automatically hides Waybar when no window is open in the current workspace.
 - Temporarily shows Waybar when the cursor is placed at the top of the screen.
 - Hides Waybar again as soon as the cursor moves away.
 - Supports multi-monitor setups
 - Supports all waybar positions (top, bottom...). See the "customization" section at the bottom.
 - Optional "always hidden" mode, which only shows the bar when the cursor is on top.
+- Optional: Reveal Waybar while holding a modifier key such as `SUPER`, `ALT`, or `CTRL`.
 - Works out of the box with no additional dependencies.
 
 ## Installation
 
-1. **Build the binary:** 
+1. **Build the binary:**
 
    ```bash
    git clone https://github.com/Zephirus2/waybar_auto_hide.git
    cd waybar_auto_hide/
-   cargo build --release   
+   cargo build --release
    ```
+
    ...or download a prebuilt binary in [releases](https://github.com/Zephirus2/waybar_auto_hide/releases/download/Release/waybar-auto_hide)
+
 2. **Copy it to your Hyprland config directory:**
+
    ```bash
    mkdir -p ~/.config/hypr/scripts
    cp target/release/waybar_auto_hide ~/.config/hypr/scripts/
@@ -31,39 +36,77 @@ A lightweight utility that automatically shows/hides Waybar in Hyprland based on
    ```
    exec-once = $HOME/.config/hypr/scripts/waybar_auto_hide &
    ```
-4. ***[RECOMENDED] Add the following lines to your waybar config***
-   
+4. **_[RECOMENDED] Add the following lines to your waybar config_**
 
-   The utility uses **SIGUSR1** and **SIGUSR2** to control visibility. By default, **SIGUSR1** toggles visibility, and **SIGUSR2** reloads the config (making the bar visible). Since Waybar can’t report its state, SIGUSR2 is the only way to ensure positive visibility    and prevent desync, though it may cause slight flicker, delay, or unnecessary I/O.
+   The utility uses **SIGUSR1** and **SIGUSR2** to control visibility. By default, **SIGUSR1** toggles visibility, and **SIGUSR2** reloads the config (making the bar visible). Since Waybar can’t report its state, SIGUSR2 is the only way to ensure positive visibility and prevent desync, though it may cause slight flicker, delay, or unnecessary I/O.
 
    It’s recommended to add the following lines to your Waybar config for smoother operation:
-      ```
-      "on-sigusr1": "hide",
-      "on-sigusr2": "show",
-      ```
 
-6. **Restart your Hyprland session** (reloading is not enough, a full reboot is recomended)
+   ```
+   "on-sigusr1": "hide",
+   "on-sigusr2": "show",
+   ```
 
+5. **Restart your Hyprland session** (reloading is not enough, a full reboot is recomended)
 
 ## Customization
 
 You can customize the behavior of waybar-auto-hide using command-line options:
 
 ### Change Waybar Position
+
 To specify which edge of the screen will be used to show waybar with the mouse, add the following argument:
+
 ```bash
 waybar_auto_hide --side [top|bottom|left|right]  #default is top
 ```
+
 ### Always Hidden Mode
+
 Enable "always hidden" mode, where Waybar only appears when you move your cursor to its edge (regardless of whether windows are open):
+
 ```bash
 waybar_auto_hide --always-hidden
 ```
+
 **Example:**
+
 ```bash
 exec-once = $HOME/.config/hypr/scripts/waybar_auto_hide --side bottom --always-hidden &
 ```
+
+### Trigger Key Reveal (Optional)
+
+You can make Waybar visible while holding the Trigger key:
+
+```bash
+waybar_auto_hide --trigger-key super
+waybar_auto_hide --trigger-key ctrl alt
+waybar_auto_hide --trigger-key super alt ctrl
+```
+
+**Example:**
+(In hyprland.conf)
+
+```bash
+exec-once = $HOME/.config/hypr/scripts/waybar_auto_hide --trigger-key super alt &
+```
+
+> This uses Linux input devices (`evdev`) to detect key presses.
+> Ensure your user has access to `/dev/input` by running:
+
+```bash
+sudo usermod -aG input $USER
+```
+
+Supported keys:
+
+- super
+- ctrl
+- alt
+- shift
+
 ## Special Thanks
+
 - [@raresgoidescu](https://github.com/raresgoidescu) for implementing multi-monitor support and direct Unix socket communication with waybar, improving performance.
 - Everyone who provided feedback, reported bugs, and opened issues!
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use clap::{Parser, ValueEnum};
+use evdev::{Key, enumerate};
 use serde::Deserialize;
 use std::{
     fs,
@@ -7,6 +8,8 @@ use std::{
     sync::mpsc::{self, Sender},
     thread,
     time::Duration,
+    collections::HashSet,
+
 };
 
 // The distance from the top at which the bar will activate
@@ -22,10 +25,12 @@ fn main() {
 
     let mut cursor_top: bool = false;
     let mut windows_opened: bool = check_windows();
+    let mut active_keys: HashSet<Key> = HashSet::new();
     let mut last_visibility: bool = !windows_opened;
 
     spawn_mouse_position_updater(tx.clone(), args.clone());
     spawn_window_event_listener(tx.clone());
+    spawn_key_listener(tx.clone());
 
     tx.send(Event::CursorTop(false)).ok();
     tx.send(Event::WindowsOpened(windows_opened)).ok();
@@ -33,16 +38,36 @@ fn main() {
     // Cache Waybar PID to avoid repeated lookups
     let mut waybar_pid = find_waybar_pid();
 
+    let mut trigger_keys: HashSet<Key> = HashSet::new();
+ 
+    if !args.trigger_keys.is_empty() {
+        trigger_keys.extend(map_trigger_keys(&args.trigger_keys));
+    }
+
     for event in rx {
         match event {
             Event::CursorTop(val) => cursor_top = val,
             Event::WindowsOpened(val) => windows_opened = val,
+
+            Event::KeyState(key, pressed) => {
+                if pressed {
+                    active_keys.insert(key);
+                } else {
+                    active_keys.remove(&key);
+                }
+            }
         }
 
+        // Trigger is active if any configured key is currently held
+        let key_trigger =
+            !trigger_keys.is_empty() && active_keys.iter().any(|k| trigger_keys.contains(k));
+
+        let trigger = cursor_top || key_trigger;
+
         let current_visible = match args.always_hidden {
-            true => cursor_top,
+            true => trigger,
             false => {
-                if cursor_top {
+                if trigger {
                     true
                 } else {
                     !windows_opened
@@ -70,13 +95,113 @@ fn main() {
     }
 }
 
+// Heuristic: select input device that exposes META key, prefer keyd virtual keyboard if present
+// NOTE: May be improved in the future by implementing more robust keyboard detection
+// or allowing manual configuration
+fn find_keyboard_device() -> Option<String> {
+    let mut fallback: Option<String> = None;
+
+    for (path, device) in enumerate() {
+        let name = device.name().unwrap_or("").to_lowercase();
+
+        if let Some(keys) = device.supported_keys() {
+            let has_super = keys.contains(Key::KEY_LEFTMETA) || keys.contains(Key::KEY_RIGHTMETA);
+
+            if has_super {
+                let path_str = path.to_string_lossy().to_string();
+
+                // Prefer keyd virtual keyboard
+                if name.contains("keyd") {
+                    println!("Using keyd device: {}", path_str);
+                    return Some(path_str);
+                }
+
+                // fallback to first valid keyboard
+                if fallback.is_none() {
+                    fallback = Some(path_str);
+                }
+            }
+        }
+    }
+
+    if let Some(ref p) = fallback {
+        println!("Using fallback keyboard: {}", p);
+    }
+
+    fallback
+}
+
+fn map_trigger_keys(keys: &[TriggerKey]) -> HashSet<Key> {
+    let mut result = HashSet::new();
+
+    for k in keys {
+        match k {
+            TriggerKey::Super => {
+                result.insert(Key::KEY_LEFTMETA);
+                result.insert(Key::KEY_RIGHTMETA);
+            }
+            TriggerKey::Ctrl => {
+                result.insert(Key::KEY_LEFTCTRL);
+                result.insert(Key::KEY_RIGHTCTRL);
+            }
+            TriggerKey::Alt => {
+                result.insert(Key::KEY_LEFTALT);
+                result.insert(Key::KEY_RIGHTALT);
+            }
+            TriggerKey::Shift => {
+                result.insert(Key::KEY_LEFTSHIFT);
+                result.insert(Key::KEY_RIGHTSHIFT);
+            }
+        }
+    }
+
+    result
+}
+
+fn spawn_key_listener(tx: Sender<Event>) {
+    use evdev::{Device, InputEventKind};
+    use std::time::Duration;
+
+    let path = find_keyboard_device().expect("No keyboard device found");
+
+    thread::spawn(move || {
+        loop {
+            match Device::open(&path) {
+                Ok(mut device) => {
+                    loop {
+                        match device.fetch_events() {
+                            Ok(events) => {
+                                for event in events {
+                                    if let InputEventKind::Key(key) = event.kind() {
+                                        // evdev key events: 1 = press, 2 = hold (repeat), 0 = release
+                                        // treat both press and hold as active to maintain "key held" behavior
+                                        let new_state = event.value() != 0;
+                                        tx.send(Event::KeyState(key, new_state)).ok();
+                                    }
+                                }
+                            }
+                            Err(_) => {
+                                // Device likely disconnected → break and reopen
+                                break;
+                            }
+                        }
+                    }
+                }
+                Err(_) => {
+                    // Retry if device not available
+                    thread::sleep(Duration::from_secs(1));
+                }
+            }
+        }
+    });
+}
+
 /// Keeps track of the mouse position
 fn spawn_mouse_position_updater(tx: Sender<Event>, args: Args) {
     thread::spawn(move || {
         let mut previous_state = false;
         loop {
             if let (Some(pos), Some(monitors)) = (get_cursor_pos(), get_monitors()) {
-                
                 // Multi-monitor fix: Find which monitor the cursor is currently on
                 // Scaling fix: Mouse position in impl Monitor
                 let active_monitor = monitors.iter().find(|m| m.contains(&pos));
@@ -95,7 +220,7 @@ fn spawn_mouse_position_updater(tx: Sender<Event>, args: Args) {
                     } else {
                         PIXEL_THRESHOLD
                     };
-                    
+
                     let is_cursor_active = distance_from_edge <= threshold;
 
                     if is_cursor_active != previous_state {
@@ -113,6 +238,7 @@ fn spawn_mouse_position_updater(tx: Sender<Event>, args: Args) {
 enum Event {
     CursorTop(bool),
     WindowsOpened(bool),
+    KeyState(Key, bool),
 }
 
 /// Helper to communicate with Hyprland Socket instead of spawning processes
@@ -228,6 +354,11 @@ struct Args {
     /// If set, the bar will always hide when the cursor is not at the top
     #[arg(long)]
     always_hidden: bool,
+
+    /// Modifier keys that trigger Waybar visibility when held (e.g. --trigger-key super alt)
+    #[arg(long = "trigger-key", num_args = 1..)]
+    trigger_keys: Vec<TriggerKey>,
+
     /// Which side of the screen the bar is located on. Beware that doesn't work well with multiple monitors.
     #[arg(long, value_enum, default_value = "top")]
     side: Side,
@@ -239,6 +370,13 @@ enum Side {
     Left,
     Right,
     Bottom,
+}
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum TriggerKey {
+    Super,
+    Ctrl,
+    Alt,
+    Shift,
 }
 
 impl Default for Side {


### PR DESCRIPTION
## Summary

This PR adds support for triggering Waybar visibility using configurable modifier keys (e.g. Super, Ctrl, Alt, Shift), in addition to the existing mouse-based trigger. (Completes #16)

## Features

- Add evdev-based key listener to detect modifier key state
- Support configurable trigger keys via CLI:
  - `--trigger-key super`
  - `--trigger-key ctrl alt`
- Multiple keys can be specified in a single flag or repeated flags
- Proper handling of key press, hold, and release events
- Integrated with existing visibility logic (mouse + window state)

## Usage

```bash
waybar_auto_hide --trigger-key super
waybar_auto_hide --trigger-key ctrl alt
waybar_auto_hide --trigger-key super shift ctrl alt