### PR TITLE
fix: ignore Waybar RT signal to prevent process termination

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,10 @@ const PIXEL_THRESHOLD_SECONDARY: i32 = 50;
 const MOUSE_REFRESH_DELAY_MS: u64 = 100;
 
 fn main() {
+    unsafe {
+        // Ignore Waybar refresh signals (used by pkill -RTMIN+X waybar)
+        libc::signal(libc::SIGRTMIN() + 9, libc::SIG_IGN);
+    }
     let args = Args::parse();
     let (tx, rx) = mpsc::channel::<Event>();
 


### PR DESCRIPTION
## Summary
Fixes an issue where the process is terminated when Waybar sends a refresh signal using:

`pkill -RTMIN+9 waybar`

Since this signal is sent to all processes named "waybar", it also affects this program. For eg. `omarchy-toggle-idle` module sends this signal.
## Fix
Ignore the corresponding real-time signal inside the application to prevent unintended termination.
## Result
The program remains running when Waybar refresh signals are triggered.